### PR TITLE
feat: add missing Whoop CSV columns (respiratory_rate, sleep_consistency, blood_oxygen_trend)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ FROM workouts GROUP BY activity ORDER BY sessions DESC;
 ### Whoop (CSV exports)
 | Data | Table | Metrics |
 |------|-------|---------|
-| Recovery | `whoop_recovery` | Score, HRV, resting HR, SpO2 |
+| Recovery | `whoop_recovery` | Score, HRV, resting HR, SpO2, respiratory rate |
 | Strain | `whoop_strain` | Day strain, calories, max/avg HR |
-| Sleep | `sleep` | Performance %, time in bed, stages |
+| Sleep | `sleep` | Performance %, time in bed, stages, consistency score |
 
 ---
 
@@ -210,7 +210,6 @@ pyproject.toml
 Good first issues:
 - Add Fitbit CSV parser
 - Add Garmin `.fit` file support
-- Add missing Whoop metrics to schema
 - Improve test coverage
 
 See [`good first issue`](../../issues?q=is%3Aissue+label%3A%22good+first+issue%22) labels to get started.

--- a/leo_health/db/schema.py
+++ b/leo_health/db/schema.py
@@ -52,6 +52,7 @@ CREATE TABLE IF NOT EXISTS sleep (
     device          TEXT,
     -- Whoop-specific aggregates (NULL for Apple Health rows)
     sleep_performance_pct   REAL,
+    sleep_consistency_score REAL,
     time_in_bed_hours       REAL,
     light_sleep_hours       REAL,
     rem_sleep_hours         REAL,
@@ -84,6 +85,8 @@ CREATE TABLE IF NOT EXISTS whoop_recovery (
     hrv_ms          REAL,
     resting_heart_rate REAL,
     spo2_pct        REAL,
+    respiratory_rate REAL,
+    blood_oxygen_trend TEXT,
     skin_temp_celsius REAL,
     created_at      TEXT DEFAULT (datetime('now'))
 );
@@ -162,7 +165,31 @@ def create_schema(db_path: str = DEFAULT_DB_PATH) -> sqlite3.Connection:
     conn = get_connection(db_path)
     conn.executescript(SCHEMA)
     conn.commit()
+    
+    # Backfill new columns for existing databases
+    _add_column_if_not_exists(conn, "whoop_recovery", "respiratory_rate", "REAL")
+    _add_column_if_not_exists(conn, "whoop_recovery", "blood_oxygen_trend", "TEXT")
+    _add_column_if_not_exists(conn, "sleep", "sleep_consistency_score", "REAL")
+    
+    conn.commit()
     return conn
+
+
+def _add_column_if_not_exists(conn: sqlite3.Connection, table: str, column: str, datatype: str):
+    """
+    Safely add a column to a table if it doesn't already exist.
+    SQLite doesn't support 'ADD COLUMN IF NOT EXISTS', so we check first.
+    """
+    try:
+        # Check if column exists by querying table info
+        cursor = conn.execute(f"PRAGMA table_info({table})")
+        columns = [row[1] for row in cursor.fetchall()]
+        
+        if column not in columns:
+            conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {datatype}")
+    except sqlite3.OperationalError:
+        # Table might not exist yet, that's okay
+        pass
 
 
 def get_stats(db_path: str = DEFAULT_DB_PATH) -> dict:

--- a/leo_health/parsers/whoop.py
+++ b/leo_health/parsers/whoop.py
@@ -43,6 +43,14 @@ def _float(val: str) -> Optional[float]:
         return None
 
 
+def _text(val: Optional[str]) -> Optional[str]:
+    """Normalize text fields: return None if empty/blank, else stripped string."""
+    if val is None:
+        return None
+    s = str(val).strip()
+    return s if s else None
+
+
 def _normalize_header(header: str) -> str:
     """Lowercase, strip, replace spaces/special chars for consistent matching."""
     return header.lower().strip().replace(" ", "_").replace("(", "").replace(")", "").replace("%", "pct").replace("/", "_per_")
@@ -99,6 +107,8 @@ def _parse_recovery_row(row: dict) -> Optional[dict]:
         "hrv_ms": hrv,
         "resting_heart_rate": rhr,
         "spo2_pct": spo2,
+        "respiratory_rate": _float(norm.get("respiratory_rate_rpm", "") or norm.get("respiratory_rate", "")),
+        "blood_oxygen_trend": _text(norm.get("blood_oxygen_trend") or norm.get("spo2_trend")),
         "skin_temp_celsius": _float(norm.get("skin_temp_celsius", "") or norm.get("skin_temp", "")),
     }
 
@@ -140,6 +150,9 @@ def _parse_sleep_row(row: dict) -> Optional[dict]:
         "recorded_at": _iso(date),
         "sleep_performance_pct": (_float(norm.get("sleep_performance_pct", "")) or
                                    _float(norm.get("sleep_performance", ""))),
+        "sleep_consistency_score": (_float(norm.get("sleep_consistency_score", "")) or
+                                     _float(norm.get("sleep_consistency_pct", "")) or
+                                     _float(norm.get("sleep_consistency", ""))),
         "time_in_bed_hours": _float(norm.get("time_in_bed_hours", "") or norm.get("total_in_bed_min_min", "")),
         "light_sleep_hours": _float(norm.get("light_sleep_duration_hours", "") or norm.get("light_sleep_min", "")),
         "rem_sleep_hours": _float(norm.get("rem_sleep_duration_hours", "") or norm.get("rem_sleep_min", "")),


### PR DESCRIPTION
Adds the three missing Whoop CSV columns mentioned in the issue #3:

respiratory_rate in whoop_recovery
blood_oxygen_trend in whoop_recovery
sleep_consistency_score in sleep

Also includes backfill logic in schema.py for existing databases.